### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/crates/vertigo-cli/Cargo.toml
+++ b/crates/vertigo-cli/Cargo.toml
@@ -6,6 +6,7 @@ description = "Reactive Real-DOM library with SSR for Rust - packaging/serving t
 categories = ["command-line-utilities", "development-tools", "development-tools::build-utils", "wasm", "web-programming"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
+repository = "https://github.com/vertigo-web/vertigo/"
 
 [[bin]]
 name = "vertigo"


### PR DESCRIPTION
to allow https://crates.io/ ,  https://lib.rs/ and https://rust-digger.code-maven.com/ to link to it
