### PR TITLE
vertigo-cli: Increased statics max-age in Cache-Control header to 1y

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@
 
 * `css` attribute in `dom!` macro now accepts `&Css` (referenced) for convenience
 
+### Changed
+
+* vertigo-cli: Increased statics max-age in Cache-Control header to 1 year to match Google's Lighthouse recommendations
+
 ## 0.6.1 - 2024-12-18
 
 ### Added

--- a/crates/vertigo-cli/src/serve/serve_run.rs
+++ b/crates/vertigo-cli/src/serve/serve_run.rs
@@ -234,7 +234,7 @@ async fn handler(
 async fn set_cache_header<B: Send>(mut response: Response<B>) -> Response<B> {
     response.headers_mut().insert(
         header::CACHE_CONTROL,
-        HeaderValue::from_static("public, max-age=86400"),
+        HeaderValue::from_static("public, max-age=31536000"),
     );
    response
 }

--- a/demo/app/src/app/render.rs
+++ b/demo/app/src/app/render.rs
@@ -124,7 +124,7 @@ pub fn render(state: &app::State) -> DomNode {
             Route::Sudoku => dom! { <Sudoku state={&state.sudoku} /> },
             Route::Input => dom! { <MyInput value={&state.input} /> },
             Route::GithubExplorer => dom! { <GitHubExplorer state={&state.github_explorer} /> },
-            Route::GameOfLife { .. } => dom! { <GameOfLife state={&state.game_of_life} /> },
+            Route::GameOfLife => dom! { <GameOfLife state={&state.game_of_life} /> },
             Route::Chat => dom! { <Chat ws_chat={&state.ws_chat}/> },
             Route::Todo => dom! { <Todo /> },
             Route::DropFile => dom! { <DropFiles /> },


### PR DESCRIPTION
1 year to match Google's Lighthouse recommendations